### PR TITLE
Feature: Change expiration time of signed upload urls generated by app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,9 @@ GCP_STATIC_BUCKET_NAME=
 GCP_PROJECT_ID=
 GCP_BUCKET_LOCATION=
 
+# Expiration time of signed urls used to upload files to Google Cloud Platform
+GCS_SIGNED_URL_LIFETIME_IN_MINUTES=1440
+
 # Site-specific content
 SITE_NAME="DataShare"
 STRAPLINE="Data sharing for everyone"

--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -30,6 +30,7 @@ SECRET_KEY = config('SECRET_KEY')
 ENABLE_SSO = config('ENABLE_SSO', default=False, cast=bool)
 SSO_REMOTE_USER_HEADER = config('SSO_REMOTE_USER_HEADER', default='HTTP_REMOTE_USER')
 SSO_LOGIN_BUTTON_TEXT = config('SSO_LOGIN_BUTTON_TEXT', default='Login')
+GCS_SIGNED_URL_LIFETIME_IN_MINUTES = config('GCS_SIGNED_URL_LIFETIME_IN_MINUTES', default=1440, cast=int)
 
 
 # Application definition

--- a/physionet-django/physionet/storage.py
+++ b/physionet-django/physionet/storage.py
@@ -14,7 +14,7 @@ class StaticStorage(GoogleCloudStorage):
     location = ''
 
 
-def generate_signed_url_helper(blob_name, size, expiration=dt.timedelta(days=1), version='v4') -> str:
+def generate_signed_url_helper(blob_name, size, expiration, version='v4') -> str:
     """
     Generate a signed URL to access project files on GCS
 

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -2313,7 +2313,7 @@ def generate_signed_url(request, project_slug):
     url = generate_signed_url_helper(
         version='v4',
         blob_name=canonical_resource,
-        expiration=dt.timedelta(days=1),
+        expiration=dt.timedelta(minutes=settings.GCS_SIGNED_URL_LIFETIME_IN_MINUTES),
         size=size
     )
 


### PR DESCRIPTION
Having such a long expiration time(1 day) on signed url is kind of a security problem. It seems that even if the the url expires when the upload has not been finished, the file itself is being uploaded properly to the GCP bucket. Based on my understanding this endpoint is called every time a file is being uploaded to the platform os I have reduced the expiration time to two minutes(just to be safe if a user is slow in his actions). We could probably reduce that time even a bit more.