### PR TITLE
Feature: Change the logic of showing access denied information

### DIFF
--- a/physionet-django/console/views.py
+++ b/physionet-django/console/views.py
@@ -1168,7 +1168,7 @@ def users_aws_access_list_json(request):
             dataset['name'] = project_name
             dataset['accounts'] = []
             for user in users_with_awsid:
-                if project.has_access(user):
+                if project.can_view_files(user):
                     dataset['accounts'].append(user.cloud_information.aws_id)
             datasets['datasets'].append(dataset)
 

--- a/physionet-django/project/modelcomponents/publishedproject.py
+++ b/physionet-django/project/modelcomponents/publishedproject.py
@@ -207,6 +207,9 @@ class PublishedProject(Metadata, SubmissionInfo):
             args=(self.slug, self.version, os.path.join(subdir, file)))
 
     def can_view_files(self, user):
+        """
+        Whether the user has access to this project and files. Extends 'is_authorized'
+        """
         return self.allow_file_downloads and self.is_authorized(user)
 
     def is_authorized(self, user):

--- a/physionet-django/project/modelcomponents/publishedproject.py
+++ b/physionet-django/project/modelcomponents/publishedproject.py
@@ -206,16 +206,16 @@ class PublishedProject(Metadata, SubmissionInfo):
         return reverse('display_published_project_file',
             args=(self.slug, self.version, os.path.join(subdir, file)))
 
-    def has_access(self, user):
+    def can_view_files(self, user):
+        return self.allow_file_downloads and self.is_authorized(user)
+
+    def is_authorized(self, user):
         """
         Whether the user has access to this project
         The logic should mirror PublishedProjectManager#accessible_by,
         but for a specific project.
         """
         if self.deprecated_files:
-            return False
-
-        if not self.allow_file_downloads:
             return False
 
         if self.access_policy == AccessPolicy.OPEN:

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -364,7 +364,7 @@
         The files in this project version are under embargo until: {{ project.embargo_end_date|date }}
       </div>
     {% else %}
-      {% if has_access %}
+      {% if can_view_files %}
         {#  refactored code goes here            #}
         <p>Total uncompressed size: {{ main_size }}.</p>
         {# ZIP START #}

--- a/physionet-django/project/templates/project/published_project.html
+++ b/physionet-django/project/templates/project/published_project.html
@@ -347,7 +347,6 @@
       <!-- /.sidebar -->
     </div>
     <h2 id="files">Files</h2>
-    {% if project.allow_file_downloads %}
     {% if project.deprecated_files %}
       <div class="alert alert-danger col-md-8" role="alert">
         {% if project.is_latest_version %}
@@ -364,7 +363,8 @@
         The files in this project version are under embargo until: {{ project.embargo_end_date|date }}
       </div>
     {% else %}
-      {% if can_view_files %}
+      {% if is_authorized %}
+        {% if project.allow_file_downloads %}
         {#  refactored code goes here            #}
         <p>Total uncompressed size: {{ main_size }}.</p>
         {# ZIP START #}
@@ -438,12 +438,12 @@
           {% include "project/files_panel.html" %}
         </div>
       {% else %}
-        {% include "project/published_project_unauthorized.html" %}
+        {% include "project/published_project_denied_downloads.html" %}
       {% endif %}
 
-    {% endif %}
-    {% else %}
-    {% include "project/published_project_denied_downloads.html" %}
+      {% else %}
+        {% include "project/published_project_unauthorized.html" %}
+      {% endif %}
     {% endif %}
     <br>
     {% if accepted_access_requests %}

--- a/physionet-django/project/templatetags/project_templatetags.py
+++ b/physionet-django/project/templatetags/project_templatetags.py
@@ -202,7 +202,7 @@ def call_method(obj, method_name, *args):
         args: arguments to be passed to the method
 
     Example:
-        {% call_method published_project 'can_view_files' request.user as user_has_access %}
+        {% call_method published_project 'can_view_files' request.user as user_can_view_files %}
     """
     method = getattr(obj, method_name)
     return method(*args)

--- a/physionet-django/project/templatetags/project_templatetags.py
+++ b/physionet-django/project/templatetags/project_templatetags.py
@@ -202,7 +202,7 @@ def call_method(obj, method_name, *args):
         args: arguments to be passed to the method
 
     Example:
-        {% call_method published_project 'has_access' request.user as user_has_access %}
+        {% call_method published_project 'can_view_files' request.user as user_has_access %}
     """
     method = getattr(obj, method_name)
     return method(*args)

--- a/physionet-django/project/views.py
+++ b/physionet-django/project/views.py
@@ -1921,7 +1921,7 @@ def sign_dua(request, project_slug, version):
         project.deprecated_files
         or project.embargo_active()
         or project.access_policy not in {AccessPolicy.RESTRICTED, AccessPolicy.CREDENTIALED}
-        or project.can_view_files(user)
+        or project.is_authorized(user)
     ):
         return redirect('published_project',
                         project_slug=project_slug, version=version)
@@ -2206,7 +2206,7 @@ def published_project_request_access(request, project_slug, version, access_type
                                             platform=access_type)
 
     # Check if the person has access to the project.
-    if not project.can_view_files(request.user):
+    if not project.is_authorized(request.user):
         return redirect('published_project', project_slug=project_slug,
             version=version)
 

--- a/physionet-django/search/templates/search/content_list.html
+++ b/physionet-django/search/templates/search/content_list.html
@@ -28,8 +28,8 @@
     <p class="pub-details">Published: {{ published_project.publish_datetime|date }}.
       Version: {{ published_project.version }}</p>
     {% if is_lightwave_supported %}
-      {% call_method published_project 'can_view_files' request.user as user_has_access %}
-      {% if published_project.has_wfdb and user_has_access %}
+      {% call_method published_project 'can_view_files' request.user as user_can_view_files %}
+      {% if published_project.has_wfdb and user_can_view_files %}
         <a href="{% url 'lightwave_home' %}?db={{ published_project.slug }}/{{ published_project.version }}"><i class="fas fa-chart-line"></i> Visualize waveforms</a>
       {% endif %}
     {% endif %}

--- a/physionet-django/search/templates/search/content_list.html
+++ b/physionet-django/search/templates/search/content_list.html
@@ -28,7 +28,7 @@
     <p class="pub-details">Published: {{ published_project.publish_datetime|date }}.
       Version: {{ published_project.version }}</p>
     {% if is_lightwave_supported %}
-      {% call_method published_project 'has_access' request.user as user_has_access %}
+      {% call_method published_project 'can_view_files' request.user as user_has_access %}
       {% if published_project.has_wfdb and user_has_access %}
         <a href="{% url 'lightwave_home' %}?db={{ published_project.slug }}/{{ published_project.version }}"><i class="fas fa-chart-line"></i> Visualize waveforms</a>
       {% endif %}


### PR DESCRIPTION
Changed the logic of the prompts to firstly show:
![image](https://user-images.githubusercontent.com/63898848/219613754-732f47a8-b445-451a-94ed-880be8328048.png)
and then:
![image](https://user-images.githubusercontent.com/63898848/219613862-3426d5ba-237d-4abe-b7b8-54acf14e7530.png)

instead of the opposite way as it is right now. This change will help user get the permissions to actually view files and check the requirements that are needed to do so.
FYI @alistairewj 