### PR TITLE
Add RESEARCH_ENVIRONMENTS_POLL_INTERVAL_MS setting (default 30s)

### DIFF
--- a/physionet-django/physionet/settings/base.py
+++ b/physionet-django/physionet/settings/base.py
@@ -738,6 +738,8 @@ ENABLE_CLOUD_RESEARCH_ENVIRONMENTS = config('ENABLE_CLOUD_RESEARCH_ENVIRONMENTS'
 
 if ENABLE_CLOUD_RESEARCH_ENVIRONMENTS:
     CLOUD_RESEARCH_ENVIRONMENTS_API_URL = config('CLOUD_RESEARCH_ENVIRONMENTS_API_URL')
+    # Client-side poll interval (ms) for live status updates on the research environments page.
+    RESEARCH_ENVIRONMENTS_POLL_INTERVAL_MS = config('RESEARCH_ENVIRONMENTS_POLL_INTERVAL_MS', default=30000, cast=int)
     INSTALLED_APPS.append('environment.apps.EnvironmentConfig')
 
 


### PR DESCRIPTION
## Summary

Adds `RESEARCH_ENVIRONMENTS_POLL_INTERVAL_MS` — the client-side poll interval (ms) for live status updates on the research environments page — as an env-configurable Django setting, default **30000** (30s).

```python
# settings/base.py, inside `if ENABLE_CLOUD_RESEARCH_ENVIRONMENTS:`
RESEARCH_ENVIRONMENTS_POLL_INTERVAL_MS = config('RESEARCH_ENVIRONMENTS_POLL_INTERVAL_MS', default=30000, cast=int)
```

## Context

The `hdn-research-environment` app now drives the environments page with polling instead of websockets, and reads this setting to decide how often to poll (pairs with **T-CAIREM/hdn-research-environment#172**). Gated behind `ENABLE_CLOUD_RESEARCH_ENVIRONMENTS`, alongside `CLOUD_RESEARCH_ENVIRONMENTS_API_URL`. Override per environment via `.env` if a different cadence is desired.

## Verification

Loaded on dev (`3.2.21rc3` image): `settings.RESEARCH_ENVIRONMENTS_POLL_INTERVAL_MS = 30000` in the running pod.
